### PR TITLE
Fix(pr): Use App token to raise pull request

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -27,6 +27,8 @@ jobs:
       issues: write  # Create pull request labels
 
     timeout-minutes: 5
+    # Dedicated environment scopes secret access (zizmor: secrets-outside-env)
+    environment: 'automation'
     env:
       # Step-level 'if' cannot access the secrets context; expose presence
       # of the bot private key as a boolean via job-level env instead
@@ -56,6 +58,11 @@ jobs:
         with:
           app-id: "${{ vars.LF_RELENG_BOT_APP_ID }}"
           private-key: "${{ secrets.LF_RELENG_BOT_PRIVATE_KEY }}"
+          # Scope the token to the permissions this workflow needs; without
+          # this the token inherits the App's blanket installation permissions
+          permission-contents: 'write'
+          permission-pull-requests: 'write'
+          permission-issues: 'write'
 
       - name: 'List existing pull requests 📋'
         env:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -27,6 +27,10 @@ jobs:
       issues: write  # Create pull request labels
 
     timeout-minutes: 5
+    env:
+      # Step-level 'if' cannot access the secrets context; expose presence
+      # of the bot private key as a boolean via job-level env instead
+      BOT_KEY_PRESENT: "${{ secrets.LF_RELENG_BOT_PRIVATE_KEY != '' }}"
     steps:
       - name: 'Harden runner 🔒'
         # yamllint disable-line rule:line-length
@@ -45,7 +49,8 @@ jobs:
       # the default GITHUB_TOKEN from creating pull requests.
       - name: 'Generate GitHub App token 🔑'
         id: app-token
-        if: vars.LF_RELENG_BOT_APP_ID != ''
+        # yamllint disable-line rule:line-length
+        if: vars.LF_RELENG_BOT_APP_ID != '' && env.BOT_KEY_PRESENT == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:

--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -40,9 +40,22 @@ jobs:
         with:
           persist-credentials: false
 
+      # Mint a short-lived GitHub App token when app credentials are
+      # configured. Required because organisations that harden Actions block
+      # the default GITHUB_TOKEN from creating pull requests.
+      - name: 'Generate GitHub App token 🔑'
+        id: app-token
+        if: vars.LF_RELENG_BOT_APP_ID != ''
+        # yamllint disable-line rule:line-length
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: "${{ vars.LF_RELENG_BOT_APP_ID }}"
+          private-key: "${{ secrets.LF_RELENG_BOT_PRIVATE_KEY }}"
+
       - name: 'List existing pull requests 📋'
         env:
-          GH_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          # yamllint disable-line rule:line-length
+          GH_TOKEN: "${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}"
         run: |
           # List pull requests with label/search
           requests=$(gh pr list -l 'automated pr')
@@ -54,4 +67,5 @@ jobs:
       - name: "Running local action: ${{ github.repository }} 🔨"
         uses: ./
         with:
-          token: "${{ secrets.GITHUB_TOKEN }}"
+          # yamllint disable-line rule:line-length
+          token: "${{ steps.app-token.outputs.token || secrets.GITHUB_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -5,26 +5,80 @@
 
 # Test Release Process
 
-Repository that automatically raises trivial changes on a schedule. Uses the
-[release-drafter](https://github.com/release-drafter/release-drafter/actions)
-action to generate draft releases. A workflow runs every morning on a
-schedule, generating a new pull request containing the current date. If a
-pull request already exists, it gets updated, so duplicates are not created.
-Manual invocation of the workflow (using workflow_dispatch) will also create a
-pull request. Test the release process by pushing a semantic tag. Pushed tags
-get tested for semantic versioning compliance, and if successful the draft
-release gets promoted.
+Repository that exercises the organisation's release tooling end-to-end. A
+scheduled workflow raises a trivial pull request (containing the current date)
+once a week; manual invocation via `workflow_dispatch` does the same on
+demand. If an automated pull request already exists, it gets updated rather
+than duplicated.
+
+Merging a pull request feeds the
+[release-drafter](https://github.com/release-drafter/release-drafter) action,
+which maintains a draft release. Test the rest of the release process by
+pushing a signed, semantic-versioned tag: the workflow checks the tag
+(versioning scheme and signature), and on success promotes the matching draft
+release to a published release.
 
 ## test-release-process
 
+## Workflow Overview
+
+1. **Generate Pull Request** (`pull-request.yaml`) — on a weekly schedule or
+   `workflow_dispatch`, writes the current date to `date.txt` and raises (or
+   updates) a pull request via the local composite action (`action.yaml`).
+2. **Release Drafter** (`release-drafter.yaml`) — on every push to `main`,
+   updates the draft release notes.
+3. **Release on Tag Push** (`tag-push.yaml`) — on a tag push, validates the
+   tag then promotes the associated draft release.
+
 ## Notes
 
-While creating releases, tests the following actions:
+While exercising the release process, this repository tests the following
+actions:
 
-- lfreleng-actions/tag-push-verify-action
-- lfreleng-actions/tag-validate-semantic-action
-- lfreleng-actions/draft-release-promote-action
+- [lfreleng-actions/tag-validate-action][tag-validate] — unified tag
+  validation (versioning scheme plus SSH/GPG signature verification, and
+  optional GitHub/Gerrit signing-key registration checks). This supersedes the
+  older `tag-push-verify-action`, `tag-validate-semantic-action`, and
+  `tag-validate-calver-action`.
+- [lfreleng-actions/draft-release-promote-action][promote] — promotes a draft
+  release to a published release.
+- [release-drafter/release-drafter][drafter] — maintains draft release notes.
+- [peter-evans/create-pull-request][cpr] — raises the automated pull request.
+- [step-security/harden-runner][harden] — runner egress hardening.
 
-Could potentially also test:
+The unified `tag-validate-action` handles both Semantic Versioning and
+Calendar Versioning tags (`require_type: semver`, `calver`, or `both`), so the
+separate `tag-validate-semantic-action` and `tag-validate-calver-action`
+repositories no longer need dedicated coverage here.
 
-- lfreleng-actions/tag-validate-calver-action
+## Automated Pull Request Permissions
+
+The scheduled workflow raises a pull request from within GitHub Actions. When
+an organisation enforces the *"Allow GitHub Actions to create and approve pull
+requests"* restriction (recommended for supply-chain hardening), the default
+`GITHUB_TOKEN` **cannot** open pull requests and the workflow fails with:
+
+```text
+GitHub Actions is not permitted to create or approve pull requests.
+```
+
+To keep the organisation hardened while still allowing this repository to
+raise its automated pull request, the workflow uses a dedicated GitHub App
+token when you configure one. Provide the following repository (or
+organisation) configuration:
+
+| Kind     | Name                        | Description                  |
+| -------- | --------------------------- | ---------------------------- |
+| Variable | `LF_RELENG_BOT_APP_ID`      | GitHub App ID                |
+| Secret   | `LF_RELENG_BOT_PRIVATE_KEY` | GitHub App private key (PEM) |
+
+The GitHub App needs `contents: write` and `pull requests: write` repository
+permissions. Install the App on this repository. Without
+`LF_RELENG_BOT_APP_ID`, the workflow falls back to `GITHUB_TOKEN`, which
+works where the organisation permits Actions to create pull requests.
+
+[tag-validate]: https://github.com/lfreleng-actions/tag-validate-action
+[promote]: https://github.com/lfreleng-actions/draft-release-promote-action
+[drafter]: https://github.com/release-drafter/release-drafter
+[cpr]: https://github.com/peter-evans/create-pull-request
+[harden]: https://github.com/step-security/harden-runner

--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ release to a published release.
 
 ## test-release-process
 
+Verifies and demonstrates the release automation used across the
+`lfreleng-actions` organisation.
+
 ## Workflow Overview
 
 1. **Generate Pull Request** (`pull-request.yaml`) — on a weekly schedule or
@@ -72,8 +75,9 @@ organisation) configuration:
 | Variable | `LF_RELENG_BOT_APP_ID`      | GitHub App ID                |
 | Secret   | `LF_RELENG_BOT_PRIVATE_KEY` | GitHub App private key (PEM) |
 
-The GitHub App needs `contents: write` and `pull requests: write` repository
-permissions. Install the App on this repository. Without
+The GitHub App needs `contents: write`, `pull-requests: write`, and
+`issues: write` repository permissions (the latter creates the
+`automated pr` label). Install the App on this repository. Without
 `LF_RELENG_BOT_APP_ID`, the workflow falls back to `GITHUB_TOKEN`, which
 works where the organisation permits Actions to create pull requests.
 


### PR DESCRIPTION
## Summary

Fixes the failing **Generate Pull Request ⬇️** workflow and modernizes the
repository documentation.

### Root cause of the PR failure

The `lfreleng-actions` organisation *enforces* the **"Allow GitHub Actions to
create and approve pull requests"** restriction (repos cannot override it — a
repo-level `PUT` returns `409 Conflict`). Because `pull-request.yaml` passed
`secrets.GITHUB_TOKEN` to `peter-evans/create-pull-request`, the run always
failed with:

```text
GitHub Actions is not permitted to create or approve pull requests.
```

### Changes

- **`pull-request.yaml`**: Mint a short-lived **GitHub App token** for the
  `lf-releng-bot` GitHub App via `actions/create-github-app-token` when its
  credentials are configured (`LF_RELENG_BOT_APP_ID` variable +
  `LF_RELENG_BOT_PRIVATE_KEY` secret), and pass it to the local action. Falls
  back to `GITHUB_TOKEN` when unconfigured. This keeps the org hardened while
  letting this repo raise its automated PR.
- **`README.md`**: Replace stale references to `tag-push-verify-action` /
  `tag-validate-semantic-action` / `tag-validate-calver-action` with the
  unified `tag-validate-action` (already used by `tag-push.yaml`). Document the
  three-workflow design and the GitHub App token requirement.

### Supporting configuration (already in place)

The `lf-releng-bot` GitHub App (App ID `4313700`) exists with org-level
credentials visible to all repositories:

| Kind     | Name                        |
| -------- | --------------------------- |
| Variable | `LF_RELENG_BOT_APP_ID`      |
| Secret   | `LF_RELENG_BOT_PRIVATE_KEY` |

The App requires installation on this repository (org-wide install pending).

*Co-authored-by: Claude*