### PR TITLE
Fix(pr): Use client-id and repair automated PR linting

### DIFF
--- a/.github/workflows/pull-request.yaml
+++ b/.github/workflows/pull-request.yaml
@@ -52,11 +52,11 @@ jobs:
       - name: 'Generate GitHub App token 🔑'
         id: app-token
         # yamllint disable-line rule:line-length
-        if: vars.LF_RELENG_BOT_APP_ID != '' && env.BOT_KEY_PRESENT == 'true'
+        if: vars.LF_RELENG_BOT_CLIENT_ID != '' && env.BOT_KEY_PRESENT == 'true'
         # yamllint disable-line rule:line-length
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: "${{ vars.LF_RELENG_BOT_APP_ID }}"
+          client-id: "${{ vars.LF_RELENG_BOT_CLIENT_ID }}"
           private-key: "${{ secrets.LF_RELENG_BOT_PRIVATE_KEY }}"
           # Scope the token to the permissions this workflow needs; without
           # this the token inherits the App's blanket installation permissions

--- a/README.md
+++ b/README.md
@@ -72,13 +72,13 @@ organisation) configuration:
 
 | Kind     | Name                        | Description                  |
 | -------- | --------------------------- | ---------------------------- |
-| Variable | `LF_RELENG_BOT_APP_ID`      | GitHub App ID                |
+| Variable | `LF_RELENG_BOT_CLIENT_ID`   | GitHub App client ID         |
 | Secret   | `LF_RELENG_BOT_PRIVATE_KEY` | GitHub App private key (PEM) |
 
 The GitHub App needs `contents: write`, `pull-requests: write`, and
 `issues: write` repository permissions (the latter creates the
 `automated pr` label). Install the App on this repository. Without
-`LF_RELENG_BOT_APP_ID`, the workflow falls back to `GITHUB_TOKEN`, which
+`LF_RELENG_BOT_CLIENT_ID`, the workflow falls back to `GITHUB_TOKEN`, which
 works where the organisation permits Actions to create pull requests.
 
 [tag-validate]: https://github.com/lfreleng-actions/tag-validate-action

--- a/action.yaml
+++ b/action.yaml
@@ -26,11 +26,22 @@ runs:
       run: |
         # Write the date to a file 📆
         date=$(date +"%Y %B %d %R %Z")
+        short_date=$(date +"%Y-%m-%d")
+        year=$(date +"%Y")
         echo "date=$date" >> "$GITHUB_OUTPUT"
+        echo "short_date=$short_date" >> "$GITHUB_OUTPUT"
         echo "Writing date to file: $date > date.txt"
         # Output inline but also output to step summary for clarity
         echo "Writing date to file: $date > date.txt" >> "$GITHUB_STEP_SUMMARY"
-        echo "$date" > date.txt
+        # SPDX tags keep the generated file REUSE compliant
+        # REUSE-IgnoreStart
+        {
+          echo "# SPDX-License-Identifier: Apache-2.0"
+          echo "# SPDX-FileCopyrightText: $year The Linux Foundation"
+          echo ""
+          echo "$date"
+        } > date.txt
+        # REUSE-IgnoreEnd
 
     - name: 'Detect change 🔍'
       id: detect
@@ -55,12 +66,15 @@ runs:
         GITHUB_TOKEN: ${{ inputs.token }}
       with:
         token: ${{ inputs.token }}
-        commit-message: ${{ steps.date.outputs.date }}
+        # Conventional commit type keeps gitlint and the semantic pull
+        # request check happy; short date keeps the subject within 50 chars
+        # yamllint disable-line rule:line-length
+        commit-message: "Chore: Update date stamp ${{ steps.date.outputs.short_date }}"
         signoff: 'true'
         sign-commits: 'true'
         branch: automated-pr
         delete-branch: true
-        title: ${{ steps.date.outputs.date }}
+        title: "Chore: Update date stamp ${{ steps.date.outputs.short_date }}"
         body: |
           ## Pull Request/Update Summary
           ${{ steps.date.outputs.date }} > date.txt


### PR DESCRIPTION
## Summary

Follow-up to #118 addressing the issues observed once the automated PR
workflow became functional (bot-raised PR #119).

### Changes

1. **`Fix(pr): Use client-id for App token minting`**
   The `app-id` input of `actions/create-github-app-token` is deprecated and
   raised console warnings on every run. Switch to `client-id`, sourced from
   the new `LF_RELENG_BOT_CLIENT_ID` org variable (already created), and
   update the README configuration table.

2. **`Fix(action): Make generated PR pass linting`**
   Bot PR #119 failed two required checks:
   - **Semantic Pull Request**: bare date title/commit subject → now
     `Chore: Update date stamp YYYY-MM-DD` (within the 50-char subject limit)
   - **pre-commit.ci / reuse lint**: `date.txt` had no licensing info → the
     generator now writes SPDX header comments into the file (echo statements
     wrapped in `REUSE-Ignore` markers so they don't parse as malformed SPDX
     expressions)

### Validation

- All pre-commit hooks pass on changed files
- zizmor 1.26.1 (auditor persona, low floor): no findings

*Co-authored-by: Claude*